### PR TITLE
Fix websocket TS build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
                 "@types/supertest": "^2.0.12",
                 "@types/unzip-stream": "^0.3.1",
                 "@types/uuid": "^9.0.1",
+                "@types/ws": "^8.5.4",
                 "@types/xml2js": "^0.4.11",
                 "antlr4ts-cli": "^0.5.0-alpha.4",
                 "concurrently": "^8.0.1",
@@ -3093,6 +3094,15 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
             "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
             "dev": true
+        },
+        "node_modules/@types/ws": {
+            "version": "8.5.4",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+            "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/xml2js": {
             "version": "0.4.11",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "@types/supertest": "^2.0.12",
         "@types/unzip-stream": "^0.3.1",
         "@types/uuid": "^9.0.1",
+        "@types/ws": "^8.5.4",
         "@types/xml2js": "^0.4.11",
         "antlr4ts-cli": "^0.5.0-alpha.4",
         "concurrently": "^8.0.1",


### PR DESCRIPTION
Simply added `@types/ws` to our dev dependencies.